### PR TITLE
LPE 783

### DIFF
--- a/app/assets/stylesheets/_print-button.scss
+++ b/app/assets/stylesheets/_print-button.scss
@@ -1,13 +1,9 @@
 .gem-c-print-link__button {
-    display: none;
+    display: inline-block;
     background: url("https://www.gov.uk/assets/government-frontend/govuk_publishing_components/icon-print-9785e3a205c49d1efe1bfe07f3b60cafe820be2d0ca670aa2f4565f5deed4d5f.png") no-repeat 10px 50%;
     background-size: 16px 18px;
     padding: 10px 10px 10px 36px;
     text-decoration: none
-}
-
-.js-enabled .gem-c-print-link__button {
-    display: inline-block
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio: 2),only screen and (min-resolution: 192dpi),only screen and (min-resolution: 2dppx) {

--- a/app/assets/stylesheets/_print-button.scss
+++ b/app/assets/stylesheets/_print-button.scss
@@ -1,9 +1,13 @@
 .gem-c-print-link__button {
-    display: inline-block;
+    display: none;
     background: url("https://www.gov.uk/assets/government-frontend/govuk_publishing_components/icon-print-9785e3a205c49d1efe1bfe07f3b60cafe820be2d0ca670aa2f4565f5deed4d5f.png") no-repeat 10px 50%;
     background-size: 16px 18px;
     padding: 10px 10px 10px 36px;
     text-decoration: none
+}
+
+.js-enabled .gem-c-print-link__button {
+    display: inline-block
 }
 
 @media only screen and (-webkit-min-device-pixel-ratio: 2),only screen and (min-resolution: 192dpi),only screen and (min-resolution: 2dppx) {

--- a/app/assets/stylesheets/_print-hide.scss
+++ b/app/assets/stylesheets/_print-hide.scss
@@ -1,0 +1,8 @@
+@media print {
+    .hmrc-sign-out-nav__link,
+    .govuk-breadcrumbs,
+    .govuk-button,
+    .gem-c-print-link__button {
+        display: none !important;
+    }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @import "_print-button.scss";
+@import "_print-hide.scss";
 
 $custom-blue-dark: #005ea5;
 $custom-blue-light: #2b8cc4;
@@ -6,6 +7,7 @@ $custom-blue-light: #2b8cc4;
 .js-visible {
   display: none !important;
 }
+
 .js-enabled .js-visible {
   display: inline-block !important;
 }

--- a/app/controllers/MembersDobController.scala
+++ b/app/controllers/MembersDobController.scala
@@ -17,12 +17,13 @@
 package controllers
 
 import com.google.inject.Inject
+import controllers.MembersDobController.consolidateMissingFieldErrors
 import controllers.actions.{CheckLockoutAction, DataRetrievalAction, IdentifierAction}
 import forms.MembersDobFormProvider
 import models.{MembersDob, Mode}
 import navigation.Navigator
 import pages.MembersDobPage
-import play.api.data.Form
+import play.api.data.{Form, FormError}
 import play.api.i18n.MessagesApi
 import play.api.mvc._
 import services.SessionCacheService
@@ -58,7 +59,11 @@ class MembersDobController @Inject()(override val messagesApi: MessagesApi,
       memberDetails =>
         form.bindFromRequest().fold(
           formWithErrors => {
-            Future.successful(BadRequest(view(formWithErrors, viewModel(mode, MembersDobPage), memberDetails.fullName)))
+            Future.successful(BadRequest(view(
+              form = consolidateMissingFieldErrors(formWithErrors),
+              viewModel = viewModel(mode, MembersDobPage),
+              name = memberDetails.fullName
+            )))
           },
           answer => {
             for {
@@ -69,5 +74,32 @@ class MembersDobController @Inject()(override val messagesApi: MessagesApi,
             }
           }
         )
+  }
+}
+
+object MembersDobController {
+  def consolidateMissingFieldErrors(form: Form[MembersDob]): Form[MembersDob] = {
+    val errs: Seq[FormError] = form.errors
+
+    val missingFieldBaseError: String = "membersDob.error.missing"
+    val missingDayOpt: Option[FormError] = errs.find(_.message == s"$missingFieldBaseError.day")
+    val missingMonthOpt: Option[FormError] = errs.find(_.message == s"$missingFieldBaseError.month")
+    val missingYearOpt: Option[FormError] = errs.find(_.message == s"$missingFieldBaseError.year")
+
+    val missingFieldErrs: Seq[FormError] = Seq(missingDayOpt, missingMonthOpt, missingYearOpt).flatten
+
+    lazy val singleConsolidatedMessage = s"$missingFieldBaseError" +
+      missingFieldErrs.map(err => {
+        err.message.stripPrefix(missingFieldBaseError)
+      }
+      ).mkString("")
+
+    missingFieldErrs match {
+      case Nil => form
+      case singleMissing@_ :: Nil => form.copy(errors = singleMissing)
+      case _ => form.copy(
+        errors = Seq(FormError("dateOfBirth", singleConsolidatedMessage))
+      )
+    }
   }
 }

--- a/app/controllers/WhatYouWillNeedController.scala
+++ b/app/controllers/WhatYouWillNeedController.scala
@@ -33,7 +33,6 @@ class WhatYouWillNeedController @Inject()(override val messagesApi: MessagesApi,
   extends MpeBaseController(identify, checkLockout, getData) {
 
   def onPageLoad(): Action[AnyContent] = handle { implicit request =>
-
     Future.successful(Ok(view(Some(routes.MpsDashboardController.redirectToMps().url))))
   }
 }

--- a/app/forms/MembersDobFormProvider.scala
+++ b/app/forms/MembersDobFormProvider.scala
@@ -29,7 +29,7 @@ class MembersDobFormProvider @Inject()(dateTimeProvider: DateTimeProvider) exten
       "dateOfBirth" -> dateOfBirth(dateTimeProvider)
         .verifying(
           firstError(
-            validDate("membersDob.error.invalid"),
+            validDate("membersDob.error.invalidDate"),
             futureDate("membersDob.error.futureDate", dateTimeProvider)
           )
         )

--- a/app/forms/mappings/Formatters.scala
+++ b/app/forms/mappings/Formatters.scala
@@ -16,15 +16,20 @@
 
 package forms.mappings
 
+import forms.mappings.Formatters.{validateInt, validateMonth}
 import play.api.data.FormError
 import play.api.data.format.Formatter
+import utils.DateFieldFormats._
+import utils.DateTimeFormats.{longMonthFormat, shortMonthFormat}
 
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoField
 import scala.util.control.Exception.nonFatalCatch
 
 trait Formatters {
   private[mappings] def stringFormatter(errorKey: String,
                                         args: Seq[String] = Seq.empty): Formatter[String] = new Formatter[String] {
-    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], String] =
+    override def bind(key: String, data: Map[String, String]): ValidationResult[String] =
       data.get(key) match {
         case None                      => Left(Seq(FormError(key, errorKey, args)))
         case Some(s) if s.trim.isEmpty => Left(Seq(FormError(key, errorKey, args)))
@@ -39,24 +44,69 @@ trait Formatters {
                                      wholeNumberKey: String,
                                      nonNumericKey: String,
                                      args: Seq[String] = Seq.empty): Formatter[Int] = new Formatter[Int] {
-      val decimalRegexp: String = """^-?(\d*\.\d*)$"""
-      private val baseFormatter: Formatter[String] = stringFormatter(requiredKey, args)
+    private val baseFormatter: Formatter[String] = stringFormatter(requiredKey, args)
 
-      override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Int] =
-        baseFormatter
-          .bind(key, data)
-          .map(_.filterNot(_.isWhitespace).replace(",", ""))
-          .flatMap {
-            case s if s.matches(decimalRegexp) =>
-              Left(Seq(FormError(key, wholeNumberKey, args)))
-            case s =>
-              nonFatalCatch
-                .either(s.toInt)
-                .left.map(_ => Seq(FormError(key, nonNumericKey, args)))
-        }
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Int] =
+      baseFormatter
+        .bind(key, data)
+        .map(_.filterNot(_.isWhitespace).replace(",", ""))
+        .flatMap(str => validateInt(str, key, wholeNumberKey, nonNumericKey))
 
-      override def unbind(key: String, value: Int): Map[String, String] =
-        baseFormatter.unbind(key, value.toString)
-    }
+    override def unbind(key: String, value: Int): Map[String, String] =
+      baseFormatter.unbind(key, value.toString)
+  }
 
+  private[mappings] def monthFormatter(requiredKey: String,
+                                       wholeNumberKey: String,
+                                       nonNumericKey: String,
+                                       invalidMonthKey: String,
+                                       args: Seq[String] = Seq.empty): Formatter[Int] = new Formatter[Int] {
+    private val baseFormatter: Formatter[String] = stringFormatter(requiredKey, args)
+
+    override def bind(key: String, data: Map[String, String]): Either[Seq[FormError], Int] =
+      baseFormatter
+        .bind(key, data)
+        .map(_.filterNot(_.isWhitespace).replace(",", ""))
+        .flatMap(str =>
+          if (str.matches(numericRegexp)){
+            validateInt(str, key, wholeNumberKey, nonNumericKey)
+          }
+          else {
+            validateMonth(str, key, invalidMonthKey)
+          }
+        )
+
+    override def unbind(key: String, value: Int): Map[String, String] =
+      baseFormatter.unbind(key, value.toString)
+  }
+
+}
+
+object Formatters {
+  def validateInt(str: String,
+                  key: String,
+                  wholeNumberKey: String,
+                  nonNumericKey: String): ValidationResult[Int] = str.filterNot(_.isWhitespace) match {
+    case decimalString if decimalString.matches(decimalRegexp) =>
+      Left(Seq(FormError(key, wholeNumberKey)))
+    case integerString if integerString.matches(integerRegexp) =>
+      Right(integerString.toInt)
+    case _ =>
+      Left(Seq(FormError(key, nonNumericKey)))
+  }
+
+  def validateMonth(str: String,
+                    key: String,
+                    invalidMonthKey: String): ValidationResult[Int] = {
+    def checkWithPattern(pattern: DateTimeFormatter): Option[Int] =
+      nonFatalCatch.opt(
+        pattern
+          .parse(str)
+          .get(ChronoField.MONTH_OF_YEAR)
+      )
+
+    (checkWithPattern(shortMonthFormat) orElse checkWithPattern(longMonthFormat))
+      .map(Right(_))
+      .getOrElse(Left(Seq[FormError](FormError(key, invalidMonthKey))))
+  }
 }

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -27,27 +27,35 @@ trait Mappings extends Formatters with Constraints {
     of(stringFormatter(errorKey, args))
 
   protected def dateOfBirth(dateTimeProvider: DateTimeProvider): Mapping[MembersDob] = {
-    val baseError = "membersDob.error.invalidOrMissing"
-    val dayError = s"$baseError.day"
-    val monthError = s"$baseError.month"
-    val yearError = s"$baseError.year"
+    val baseError = "membersDob.error"
+    val baseFormatError = s"$baseError.format"
+    val baseMissingError = s"$baseError.missing"
+
+    val dayString: String = "day"
+    val monthString: String = "month"
+    val yearString: String = "year"
+
+    val dayError = s"$baseFormatError.$dayString"
+    val monthError = s"$baseFormatError.$monthString"
+    val yearError = s"$baseFormatError.$yearString"
 
     mapping(
-      "day" -> int(
-        requiredKey = dayError,
+      dayString -> int(
+        requiredKey = s"$baseMissingError.$dayString",
         wholeNumberKey = dayError,
         nonNumericKey = dayError
-      ).verifying(dayError, d => d > 0 && d < 32),
-      "month" -> int(
-        requiredKey = monthError,
+      ).verifying(dayError, day => day > 0 && day < 32),
+      monthString -> month(
+        requiredKey = s"$baseMissingError.$monthString",
         wholeNumberKey = monthError,
-        nonNumericKey = monthError
-      ).verifying(monthError, m => m > 0 && m < 13),
-      "year" -> int(
-        requiredKey = yearError,
+        nonNumericKey = monthError,
+        invalidMonthKey = s"$monthError.nonNumeric"
+      ).verifying(monthError, month => month >= 1 && month <= 12),
+      yearString -> int(
+        requiredKey = s"$baseMissingError.$yearString",
         wholeNumberKey = yearError,
         nonNumericKey = yearError
-      ).verifying(yearError, y => y >= minYear && y <= dateTimeProvider.now().getYear)
+      ).verifying(yearError, year => year >= minYear && year <= dateTimeProvider.now().getYear)
     )(MembersDob.apply)(MembersDob.unapply)
   }
 
@@ -55,4 +63,10 @@ trait Mappings extends Formatters with Constraints {
                     wholeNumberKey: String,
                     nonNumericKey: String): FieldMapping[Int] =
     of(intFormatter(requiredKey, wholeNumberKey, nonNumericKey))
+
+  protected def month(requiredKey: String,
+                      wholeNumberKey: String,
+                      nonNumericKey: String,
+                      invalidMonthKey: String): FieldMapping[Int] =
+    of(monthFormatter(requiredKey, wholeNumberKey, nonNumericKey, invalidMonthKey))
 }

--- a/app/forms/mappings/package.scala
+++ b/app/forms/mappings/package.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import play.api.data.FormError
+
+package object mappings {
+  type ValidationResult[R] = Either[Seq[FormError], R]
+}

--- a/app/utils/DateFieldFormats.scala
+++ b/app/utils/DateFieldFormats.scala
@@ -19,5 +19,5 @@ package utils
 object DateFieldFormats {
   val numericRegexp: String = """^[\d\.]+$"""
   val decimalRegexp: String = """^-?(\d*\.\d*)$"""
-  val integerRegexp: String = """^-?(\d*)$"""
+  val integerRegexp: String = """^-?(\d+)$"""
 }

--- a/app/utils/DateFieldFormats.scala
+++ b/app/utils/DateFieldFormats.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+object DateFieldFormats {
+  val numericRegexp: String = """^[\d\.]+$"""
+  val decimalRegexp: String = """^-?(\d*\.\d*)$"""
+  val integerRegexp: String = """^-?(\d*)$"""
+}

--- a/app/utils/DateTimeFormats.scala
+++ b/app/utils/DateTimeFormats.scala
@@ -28,6 +28,10 @@ object DateTimeFormats {
   private val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd MMMM yyyy 'at' h:mma")
   val apiDateTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
+  val shortMonthFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("MMM")
+  val longMonthFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("LLLL")
+
+
   private val localisedDateFormatters = Map(
     "en" -> dateFormatter,
     "cy" -> dateFormatter.withLocale(new Locale("cy"))

--- a/app/viewmodels/govuk/InputFluency.scala
+++ b/app/viewmodels/govuk/InputFluency.scala
@@ -40,7 +40,7 @@ trait InputFluency {
       input.copy(hint = Some(hint))
 
     def withCssClass(newClass: String): Input =
-      input.copy(classes = s"${input.classes} $newClass")
+      input.copy(classes = s"${input.classes.strip()} $newClass")
 
     def withAutocomplete(value: String): Input =
       input.copy(autocomplete = Some(value))

--- a/app/viewmodels/govuk/LabelFluency.scala
+++ b/app/viewmodels/govuk/LabelFluency.scala
@@ -32,6 +32,8 @@ trait LabelFluency {
         .withCssClass(size.toString)
 
     def withCssClass(className: String): Label =
-      label.copy(classes = s"${label.classes} $className")
+      label.copy(
+        classes = s"${label.classes.strip()} $className"
+      )
   }
 }

--- a/app/views/MembersNinoView.scala.html
+++ b/app/views/MembersNinoView.scala.html
@@ -16,6 +16,7 @@
 
 @import views.html.components._
 @import viewmodels.InputWidth.Fixed10
+@import viewmodels.LabelSize.Large
 @import viewmodels.formPage._
 @import viewmodels.govuk._
 @import viewmodels._
@@ -45,8 +46,8 @@
                 label = LabelViewModel(
                     s"${messages("membersNino.heading", name)}"
                 )
-                .asPageHeading()
-                .withCssClass("govuk-label--l govuk-!-margin-bottom-6")
+                .asPageHeading(Large)
+                .withCssClass("govuk-!-margin-bottom-6")
             )
             .withWidth(Fixed10)
             .withHint(HintViewModel(Text(messages("membersNino.hint"))))

--- a/app/views/MembersPsaCheckRefView.scala.html
+++ b/app/views/MembersPsaCheckRefView.scala.html
@@ -15,6 +15,7 @@
  *@
 
 @import views.html.components._
+@import viewmodels.LabelSize.Large
 @import viewmodels.InputWidth.Fixed10
 @import viewmodels.formPage._
 @import viewmodels.govuk._
@@ -45,8 +46,8 @@
                 label = LabelViewModel(
                     s"${messages("membersPsaCheckRef.heading", name)}"
                 )
-                .asPageHeading()
-                .withCssClass("govuk-label--l govuk-!-margin-bottom-6")
+                .asPageHeading(Large)
+                .withCssClass("govuk-!-margin-bottom-6")
            )
            .withWidth(Fixed10)
            .withHint(HintViewModel(Text(messages("membersPsaCheckRef.hint"))))

--- a/app/views/NoResultsView.scala.html
+++ b/app/views/NoResultsView.scala.html
@@ -68,8 +68,6 @@
             @messages("noResults.checkInformation") <a class="govuk-link" href="@routes.CheckYourAnswersController.onPageLoad()">@messages("noResults.tryAgain")</a>@messages("noResults.period")
         </p>
 
-        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
         @printSection(formattedTimestamp)
     </div>
 }

--- a/app/views/NoResultsView.scala.html
+++ b/app/views/NoResultsView.scala.html
@@ -65,7 +65,13 @@
         </ul>
 
         <p class="govuk-body govuk-!-margin-bottom-8">
-            @messages("noResults.checkInformation") <a class="govuk-link" href="@routes.CheckYourAnswersController.onPageLoad()">@messages("noResults.tryAgain")</a>@messages("noResults.period")
+            @messages("noResults.checkInformation")
+
+            <a class="govuk-link" href="@routes.CheckYourAnswersController.onPageLoad().absoluteURL()">
+                @messages("noResults.tryAgain")
+            </a>
+
+            @messages("noResults.period")
         </p>
 
         @printSection(formattedTimestamp)

--- a/app/views/ResultsView.scala.html
+++ b/app/views/ResultsView.scala.html
@@ -62,9 +62,7 @@
 
     @printSection(formattedTimestamp)
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-    <nav role="navigation">
+    <nav role="navigation" class="govuk-!-margin-top-8">
         @h2("results.relatedContent", marginBottom = "6")
         <ul class="govuk-list govuk-!-margin-bottom-6">
             <li>

--- a/app/views/ResultsView.scala.html
+++ b/app/views/ResultsView.scala.html
@@ -66,12 +66,12 @@
         @h2("results.relatedContent", marginBottom = "6")
         <ul class="govuk-list govuk-!-margin-bottom-6">
             <li>
-                <a class="govuk-link" href="@routes.ClearCacheController.onPageLoad()">
+                <a class="govuk-link" href="@routes.ClearCacheController.onPageLoad().absoluteURL()">
                     @messages("results.checkAnotherMpe")
                 </a>
             </li>
             <li>
-                <a class="govuk-link" href="@routes.MpsDashboardController.redirectToMps()">
+                <a class="govuk-link" href="@routes.MpsDashboardController.redirectToMps().absoluteURL()">
                     @messages("results.mpsDashboard")
                 </a>
             </li>

--- a/app/views/ViewUtils.scala
+++ b/app/views/ViewUtils.scala
@@ -28,7 +28,9 @@ object ViewUtils {
     )
 
   def titleNoForm(title: String, section: Option[String] = None)(implicit messages: Messages): String =
-    s"${messages(title)} - ${section.fold("")(messages(_) + " - ")}${messages("service.name")}"
+    s"${messages(title)} - " +
+      s"${section.fold("")(messages(_) + " - ")}" +
+      s"${messages("service.name")} - ${messages("site.govuk")}"
 
   def errorPrefix(form: Form[_])(implicit messages: Messages): String = {
     if (form.hasErrors || form.hasGlobalErrors) messages("error.title.prefix") else ""

--- a/app/views/WhatYouWillNeedView.scala.html
+++ b/app/views/WhatYouWillNeedView.scala.html
@@ -67,18 +67,10 @@
        role="button"
        draggable="false"
        class="govuk-button govuk-button--start"
-       data-module="govuk-button" data-govuk-button-init=""
-       data-govuk-button-module-started="true">
+       data-module="govuk-button">
         @messages("site.continue")
-        <svg class="govuk-button__start-icon"
-             xmlns="http://www.w3.org/2000/svg"
-             width="17.5"
-             height="19"
-             viewBox="0 0 33 40"
-             aria-hidden="true"
-             focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
         </svg>
     </a>
-
 }

--- a/app/views/WhatYouWillNeedView.scala.html
+++ b/app/views/WhatYouWillNeedView.scala.html
@@ -22,6 +22,7 @@
     govukButton : GovukButton,
     govukBackLink: GovukBackLink,
     heading: h1,
+    heading2: h2,
     appConfig: FrontendAppConfig,
     govukBreadcrumbs: GovukBreadcrumbs
 )
@@ -37,22 +38,27 @@
 
     <p class="govuk-body">@messages("whatYouWillNeed.p1")</p>
 
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+    <ul class="govuk-list govuk-list--bullet">
         <li>@messages("whatYouWillNeed.full_name")</li>
         <li>@messages("whatYouWillNeed.dob")</li>
         <li>@messages("whatYouWillNeed.nino")</li>
-        <li>@messages("whatYouWillNeed.pension_scheme_admin_check_ref")</li>
+        <li>@messages("whatYouWillNeed.pension_scheme_admin_check_ref.li")</li>
     </ul>
+
+    @heading2("whatYouWillNeed.pension_scheme_admin_check_ref.h2")
 
     <p class="govuk-body">@messages("whatYouWillNeed.guidance.p1")</p>
 
     <p class="govuk-body">@messages("whatYouWillNeed.guidance.p2")</p>
 
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+    <ul class="govuk-list govuk-list--bullet">
         <li>@messages("whatYouWillNeed.guidance.li.1")</li>
         <li>
             @messages("whatYouWillNeed.guidance.li.2")
-            <a class="govuk-link" href="@appConfig.checkLtaGuidanceUrl">
+            <a class="govuk-link govuk-link--no-visited-state"
+               href="@appConfig.checkLtaGuidanceUrl"
+               rel="noreferrer"
+               target="_blank">
                 @messages("whatYouWillNeed.guidance.li.2.linkText")
             </a>
         </li>
@@ -64,7 +70,7 @@
        draggable="false"
        class="govuk-button govuk-button--start"
        data-module="govuk-button">
-        @messages("site.continue")
+        @messages("site.start")
         <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
             <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
         </svg>

--- a/app/views/WhatYouWillNeedView.scala.html
+++ b/app/views/WhatYouWillNeedView.scala.html
@@ -16,7 +16,6 @@
 
 @import views.html.components._
 @import config.FrontendAppConfig
-@import viewmodels.MpeBreadcrumbs._
 
 @this(
     layout: templates.Layout,
@@ -27,14 +26,11 @@
     govukBreadcrumbs: GovukBreadcrumbs
 )
 
-@(
-    backLinkUrl: Option[String]
-)(implicit request: Request[_], messages: Messages)
+@(backLinkUrl: Option[String])(implicit request: Request[_], messages: Messages)
 
 @layout(
-        pageTitle = titleNoForm(messages("whatYouWillNeed.title")),
-        backLinkUrl = backLinkUrl,
-        beforeContent = Some(govukBreadcrumbs(Breadcrumbs(mpePageBreadcrumbs)))
+    pageTitle = titleNoForm(messages("whatYouWillNeed.title")),
+    backLinkUrl = backLinkUrl
 ) {
 
     @heading("whatYouWillNeed.heading", headerSize = "l")

--- a/app/views/WhatYouWillNeedView.scala.html
+++ b/app/views/WhatYouWillNeedView.scala.html
@@ -37,7 +37,7 @@
         beforeContent = Some(govukBreadcrumbs(Breadcrumbs(mpePageBreadcrumbs)))
 ) {
 
-    @heading("whatYouWillNeed.heading", headerSize = "xl")
+    @heading("whatYouWillNeed.heading", headerSize = "l")
 
     <p class="govuk-body">@messages("whatYouWillNeed.p1")</p>
 

--- a/app/views/auth/SessionTimeoutView.scala.html
+++ b/app/views/auth/SessionTimeoutView.scala.html
@@ -22,14 +22,14 @@
     pageTitle = titleNoForm(messages("sessionTimeout.title")),
     timeout   = false
 ) {
+    <h1 class="govuk-heading-l">@messages("sessionTimeout.heading")</h1>
 
-    <h1 class="govuk-heading-xl">@messages("sessionTimeout.heading")</h1>
-
-    <p class="govuk-body">
-        @messages("sessionTimeout.body.1")
-        <a class="govuk-link" href="@routes.WhatYouWillNeedController.onPageLoad()">
-            @messages("sessionTimeout.body.signInLink")
-        </a>
-        @messages("sessionTimeout.body.2")
-    </p>
+    <form class="form" action="@routes.WhatYouWillNeedController.onPageLoad()" method="get">
+        <div class="govuk-button-group">
+            <button id="timeout-signin-btn"
+                    class="govuk-button govuk-!-margin-bottom-0">
+                @messages("sessionTimeout.signIn")
+            </button>
+        </div>
+    </form>
 }

--- a/app/views/components/print_button.scala.html
+++ b/app/views/components/print_button.scala.html
@@ -20,7 +20,7 @@
 
 @(marginTop: Int = 40, marginBottom: Int = 40, classes: String = "", buttonId: Int = 1)(implicit request: Request[_], messages: Messages)
 
-<div class="gem-c-print-link govuk-!-display-none-print govuk-!-margin-top-@{marginTop} govuk-!-margin-bottom-@{marginBottom} @classes">
+<div class="display-none govuk-!-display-none-print govuk-!-margin-top-@{marginTop} govuk-!-margin-bottom-@{marginBottom} @classes">
  <button class="govuk-link govuk-body-s gem-c-print-link__button" id="print-button-@{buttonId}">
    @messages("site.print")
  </button>
@@ -28,7 +28,7 @@
 
 <script @CSPNonce.attr>
  var printButton = document.getElementById('print-button-@{buttonId}');
-     printButton.addEventListener('click', function() {
-         window.print();
-     });
+ printButton.addEventListener('click', function() {
+  window.print();
+ });
 </script>

--- a/app/views/components/print_button.scala.html
+++ b/app/views/components/print_button.scala.html
@@ -20,7 +20,7 @@
 
 @(marginTop: Int = 40, marginBottom: Int = 40, classes: String = "", buttonId: Int = 1)(implicit request: Request[_], messages: Messages)
 
-<div class="display-none govuk-!-display-none-print govuk-!-margin-top-@{marginTop} govuk-!-margin-bottom-@{marginBottom} @classes">
+<div class="js-visible govuk-!-margin-top-@{marginTop} govuk-!-margin-bottom-@{marginBottom} @classes">
  <button class="govuk-link govuk-body-s gem-c-print-link__button" id="print-button-@{buttonId}">
    @messages("site.print")
  </button>

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -49,7 +49,7 @@
 )
 
 @head = {
-<link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen" rel="stylesheet" type="text/css" />
+<link href='@controllers.routes.Assets.versioned("stylesheets/application.css")' media="screen, print" rel="stylesheet" type="text/css" />
     @if(timeout) {
         @hmrcTimeoutDialog(TimeoutDialog(
             timeout             = Some(appConfig.timeout),

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -36,7 +36,7 @@ play.modules.enabled += "config.Module"
 
 play.filters.enabled += play.filters.csp.CSPFilter
 
-play.i18n.langs = ["en", "cy"]
+play.i18n.langs = ["en"]
 
 microservice {
     services {

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -63,19 +63,20 @@ sessionTimeout.title = For your security, we signed you out
 sessionTimeout.heading = For your security, we signed you out
 sessionTimeout.signIn = Sign in
 
-whatYouWillNeed.title = What you''ll need
-whatYouWillNeed.heading = What you''ll need
+whatYouWillNeed.title = Check a pension scheme member's protections and enhancements
+whatYouWillNeed.heading = Check a pension scheme member''s protections and enhancements
 whatYouWillNeed.p1 = You''ll need the member''s:
 whatYouWillNeed.full_name = full name
 whatYouWillNeed.dob = date of birth
 whatYouWillNeed.nino = National Insurance number
-whatYouWillNeed.pension_scheme_admin_check_ref = pension scheme administrator check reference
+whatYouWillNeed.pension_scheme_admin_check_ref.li = pension scheme administrator check reference
 
-whatYouWillNeed.guidance.p1 = Ask the member for the pension scheme administrator check reference if you do not already have it.
+whatYouWillNeed.pension_scheme_admin_check_ref.h2 = Pension scheme administrator check reference
+whatYouWillNeed.guidance.p1 = Ask the member for the reference if you do not already have it.
 whatYouWillNeed.guidance.p2 = They can find the reference:
 whatYouWillNeed.guidance.li.1 = on their protection certificate or confirmation letter
 whatYouWillNeed.guidance.li.2 = when they
-whatYouWillNeed.guidance.li.2.linkText = check the protected allowances on their pension savings
+whatYouWillNeed.guidance.li.2.linkText = check the protected allowances on their pension savings (opens in new tab)
 whatYouWillNeed.guidance.li.3 = by contacting HMRC if their protection or enhancement is from before 2014
 
 membersName.title = What is the member''s name?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -96,11 +96,20 @@ membersDob.title = What is the member''s date of birth?
 membersDob.heading = What is {0}''s date of birth?
 membersDob.hint = For example, 27 03 1970
 membersDob.dob = Date of birth
-membersDob.error.invalid = Enter a valid date
-membersDob.error.invalidOrMissing.day = Enter a day between 1 and 31
-membersDob.error.invalidOrMissing.month = Enter a month between 1 and 12
-membersDob.error.invalidOrMissing.year = Enter a year between 1900 and current year
+membersDob.error.missing.day.month.year = Enter the member''s date of birth
+membersDob.error.missing.day.month = The member''s date of birth must include a day and a month
+membersDob.error.missing.day.year = The member''s date of birth must include a day and a year
+membersDob.error.missing.month.year = The member''s date of birth must include a month and a year
+membersDob.error.missing.day = The member''s date of birth must include a day
+membersDob.error.missing.month = The member''s date of birth must include a month
+membersDob.error.missing.year =  The member''s date of birth must include a year
+
+membersDob.error.format.day = Enter a day between 1 and 31
+membersDob.error.format.month = Enter a month between 1 and 12
+membersDob.error.format.month.nonNumeric = Enter a month between January and December
+membersDob.error.format.year = Enter a year between 1900 and current year
 membersDob.error.futureDate = The member''s date of birth must be in the past
+membersDob.error.invalidDate = The member''s date of birth must be a real date
 
 membersNino.title = What is the member''s National Insurance number?
 membersNino.heading = What is {0}''s National Insurance number?

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -63,7 +63,7 @@ sessionTimeout.title = For your security, we signed you out
 sessionTimeout.heading = For your security, we signed you out
 sessionTimeout.signIn = Sign in
 
-whatYouWillNeed.title = Check a pension scheme member's protections and enhancements
+whatYouWillNeed.title = Check a pension scheme member''s protections and enhancements
 whatYouWillNeed.heading = Check a pension scheme member''s protections and enhancements
 whatYouWillNeed.p1 = You''ll need the member''s:
 whatYouWillNeed.full_name = full name

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -59,11 +59,9 @@ lockedOut.p2 = Try again in {0}
 lockedOut.p2.minutes = minutes.
 lockedOut.p2.minute = minute.
 
-sessionTimeout.title = You''ve been signed out due to inactivity
-sessionTimeout.heading = You''ve been signed out due to inactivity
-sessionTimeout.body.1 = You''ll need to
-sessionTimeout.body.signInLink = sign in
-sessionTimeout.body.2 = again.
+sessionTimeout.title = For your security, we signed you out
+sessionTimeout.heading = For your security, we signed you out
+sessionTimeout.signIn = Sign in
 
 whatYouWillNeed.title = What you''ll need
 whatYouWillNeed.heading = What you''ll need

--- a/test/connectors/MembersCheckAndRetrieveConnectorSpec.scala
+++ b/test/connectors/MembersCheckAndRetrieveConnectorSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import models.errors.{NotFoundError, InternalError}
+import models.errors.{InternalError, NotFoundError}
 import models.requests.PensionSchemeMemberRequest
 import models.response.RecordStatusMapped.Active
 import models.response.RecordTypeMapped.FixedProtection2016

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import models._
-import pages.{MembersDobPage, MembersNinoPage, MembersPsaCheckRefPage, ResultsPage, WhatIsTheMembersNamePage}
+import pages._
 import play.api.http.Status.OK
 import play.api.i18n.Messages
 import play.api.test.FakeRequest

--- a/test/controllers/MembersDobControllerSpec.scala
+++ b/test/controllers/MembersDobControllerSpec.scala
@@ -19,7 +19,6 @@ package controllers
 import base.SpecBase
 import forms.MembersDobFormProvider
 import models.{MemberDetails, MembersDob, MembersResult, NormalMode}
-import org.scalatest.Assertion
 import pages.{MembersDobPage, ResultsPage, WhatIsTheMembersNamePage}
 import play.api.data.{Form, FormError}
 import play.api.test.FakeRequest

--- a/test/controllers/MembersDobControllerSpec.scala
+++ b/test/controllers/MembersDobControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import forms.MembersDobFormProvider
 import models.{MemberDetails, MembersDob, MembersResult, NormalMode}
 import pages.{MembersDobPage, ResultsPage, WhatIsTheMembersNamePage}
-import play.api.data.Form
+import play.api.data.{Form, FormError}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import viewmodels.formPage.FormPageViewModel
@@ -102,13 +102,17 @@ class MembersDobControllerSpec extends SpecBase {
           .withFormUrlEncodedBody(
             "dateOfBirth.day" -> "",
             "dateOfBirth.month" -> "",
-            "dateOfBirth.year" -> "")
+            "dateOfBirth.year" -> ""
+          )
 
         val result = route(application, request).value
 
         val view = application.injector.instanceOf[MembersDobView]
         val viewModel: FormPageViewModel = getFormPageViewModel(onSubmit, backLinkUrl)
-        val formWithErrors = form.bind(Map("dateOfBirth.day" -> "", "dateOfBirth.month" -> "", "dateOfBirth.year" -> ""))
+
+        val formWithErrors: Form[MembersDob] = form
+          .bind(Map("dateOfBirth.day" -> "", "dateOfBirth.month" -> "", "dateOfBirth.year" -> ""))
+          .copy(errors = Seq(FormError("dateOfBirth", "membersDob.error.missing.day.month.year")))
 
         status(result) mustEqual BAD_REQUEST
         contentAsString(result) mustEqual view(formWithErrors, viewModel, "Pearl Harvey")(request, messages(application)).toString
@@ -117,7 +121,6 @@ class MembersDobControllerSpec extends SpecBase {
     }
 
     "must redirect to WhatIsTheMembersNamePage when no members details exists" in {
-
       val userAnswers = emptyUserAnswers
       val application = applicationBuilder(userAnswers).build()
 

--- a/test/controllers/MembersDobControllerSpec.scala
+++ b/test/controllers/MembersDobControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import base.SpecBase
 import forms.MembersDobFormProvider
 import models.{MemberDetails, MembersDob, MembersResult, NormalMode}
+import org.scalatest.Assertion
 import pages.{MembersDobPage, ResultsPage, WhatIsTheMembersNamePage}
 import play.api.data.{Form, FormError}
 import play.api.test.FakeRequest
@@ -148,6 +149,51 @@ class MembersDobControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual routes.ClearCacheController.onPageLoad().url
+      }
+    }
+
+    ".consolidateMissingFieldErrors" - {
+      "must return original form when no errors exist" in {
+        val boundForm = form.bind(Map(
+          "dateOfBirth.day" -> "11",
+          "dateOfBirth.month" -> "11",
+          "dateOfBirth.year" -> "1900"
+        ))
+
+        MembersDobController.consolidateMissingFieldErrors(boundForm) mustBe boundForm
+      }
+
+      "must return original form with errors when no fields are missing" in {
+        val boundForm = form.bind(Map(
+          "dateOfBirth.day" -> "13",
+          "dateOfBirth.month" -> "11",
+          "dateOfBirth.year" -> "1900"
+        ))
+
+        MembersDobController.consolidateMissingFieldErrors(boundForm) mustBe boundForm
+      }
+
+      "must return original form with only missing field errors when they exist" in {
+        val boundForm = form.bind(Map(
+          "dateOfBirth.day" -> "",
+          "dateOfBirth.month" -> "11",
+          "dateOfBirth.year" -> "1900"
+        ))
+
+        val result: Form[MembersDob] = MembersDobController.consolidateMissingFieldErrors(boundForm)
+        result.errors must have length 1
+        result.errors must contain(FormError("dateOfBirth.day", "membersDob.error.missing.day"))
+      }
+
+      "must return original form with consolidated missing field errors when multiple exist" in {
+        val boundForm = form.bind(Map(
+          "dateOfBirth.day" -> "",
+          "dateOfBirth.year" -> "1900"
+        ))
+
+        val result: Form[MembersDob] = MembersDobController.consolidateMissingFieldErrors(boundForm)
+        result.errors must have length 1
+        result.errors must contain(FormError("dateOfBirth", "membersDob.error.missing.day.month"))
       }
     }
   }

--- a/test/forms/mappings/FormattersSpec.scala
+++ b/test/forms/mappings/FormattersSpec.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.mappings
+
+import forms.mappings.Formatters.{validateInt, validateMonth}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import play.api.data.FormError
+import play.api.data.format.Formatter
+
+class FormattersSpec extends AnyFreeSpec with Matchers with OptionValues with Mappings {
+  "stringFormatter" - {
+    val testStringFormatter = stringFormatter("error")
+
+    "must bind a valid string" in {
+      val result: Either[Seq[FormError], String] = testStringFormatter.bind("value", Map("value" -> "foobar"))
+      result.toOption mustBe Some("foobar")
+    }
+
+    "must not bind an empty string" in {
+      val result: Either[Seq[FormError], String] = testStringFormatter.bind("value", Map("value" -> ""))
+      result.swap.getOrElse(Nil) must contain(FormError("value", "error"))
+    }
+
+    "must not bind a string of whitespace only" in {
+      val result: Either[Seq[FormError], String] = testStringFormatter.bind("value", Map("value" -> " \t"))
+      result.swap.getOrElse(Nil) must contain(FormError("value", "error"))
+    }
+
+    "must not bind an empty map" in {
+      val result: Either[Seq[FormError], String] = testStringFormatter.bind("value", Map.empty[String, String])
+      result.swap.getOrElse(Nil) must contain(FormError("value", "error"))
+    }
+
+    "must unbind a valid value" in {
+      val result = testStringFormatter.unbind("value", "foo")
+      result.apply("value") mustBe "foo"
+    }
+  }
+
+  "intFormatter" - {
+    val testIntFormatter: Formatter[Int] = intFormatter("required", "wholeNumber", "nonNumeric")
+
+    "must bind a valid string" in {
+      val intVal: Int = 39
+      val result = testIntFormatter.bind("value", Map("value" -> intVal.toString))
+      result mustBe a[Right[_, _]]
+      result mustBe Right(intVal)
+    }
+
+    "must not bind a valid decimal string" in {
+      val decimalVal: Double = 39.3
+      val result = testIntFormatter.bind("value", Map("value" -> decimalVal.toString))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "wholeNumber"))
+    }
+
+    "must ignore whitespace" in {
+      val intVal: Int = 39
+      val result = testIntFormatter.bind("value", Map("value" -> s"     $intVal"))
+      result mustBe a[Right[_, _]]
+      result mustBe Right(intVal)
+    }
+
+    "must not bind an empty string" in {
+      val result = testIntFormatter.bind("value", Map("value" -> ""))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "required"))
+    }
+
+    "must not bind an empty map" in {
+      val result = testIntFormatter.bind("value", Map.empty[String, String])
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "required"))
+    }
+
+    "must not bind any other invalid string" in {
+      val result = testIntFormatter.bind("value", Map("value" -> "beep"))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "nonNumeric"))
+    }
+  }
+
+  "monthFormatter" - {
+    val testMonthFormatter: Formatter[Int] = monthFormatter("required", "wholeNumber", "nonNumeric", "invalidMonth")
+
+    "must bind a valid month int" in {
+      val intVal: Int = 11
+      val result = testMonthFormatter.bind("value", Map("value" -> intVal.toString))
+      result mustBe a[Right[_, _]]
+      result mustBe Right(intVal)
+    }
+
+    "must bind a valid month short code" in {
+      val shortVal: String = "Jan"
+      val intVal: Int = 1
+      val result = testMonthFormatter.bind("value", Map("value" -> shortVal))
+      result mustBe a[Right[_, _]]
+      result mustBe Right(intVal)
+    }
+
+    "must bind a valid month long code" in {
+      val shortVal: String = "January"
+      val intVal: Int = 1
+      val result = testMonthFormatter.bind("value", Map("value" -> shortVal))
+      result mustBe a[Right[_, _]]
+      result mustBe Right(intVal)
+    }
+
+    "must not bind an empty string" in {
+      val result = testMonthFormatter.bind("value", Map("value" -> ""))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "required"))
+    }
+
+    "must not bind an empty map" in {
+      val result = testMonthFormatter.bind("value", Map.empty[String, String])
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "required"))
+    }
+
+    "must not bind an invalid numeric string" in {
+      val result = testMonthFormatter.bind("value", Map("value" -> "123..123.2323.2323"))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "nonNumeric"))
+    }
+
+    "must not bind any other invalid string" in {
+      val result = testMonthFormatter.bind("value", Map("value" -> "beep"))
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "invalidMonth"))
+    }
+  }
+
+  "validateInt" - {
+    "should complete successfully for a valid submission" in {
+      validateInt("1", "value", "err", "err") mustBe Right(1)
+    }
+
+    "should return an error for a decimal string" in {
+      val result: ValidationResult[Int] = validateInt("1.1", "value", "wholeNumber", "err")
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "wholeNumber"))
+    }
+
+    "should return an error for a non numeric string" in {
+      val result: ValidationResult[Int] = validateInt("N/A", "value", "err", "nonNumeric")
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "nonNumeric"))
+    }
+
+    "should return an error for an empty string" in {
+      val result: ValidationResult[Int] = validateInt("", "value", "err", "nonNumeric")
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "nonNumeric"))
+    }
+  }
+
+  "validateMonth" - {
+    "should complete successfully for a valid short submission" in {
+      validateMonth("Jan", "value", "err") mustBe Right(1)
+    }
+
+    "should complete successfully for a valid long submission" in {
+      validateMonth("March", "value", "err") mustBe Right(3)
+    }
+
+    "should return an error for an invalid string" in {
+      val result: ValidationResult[Int] = validateMonth("N/A", "value", "err")
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "err"))
+    }
+
+    "should return an error for an empty string" in {
+      val result: ValidationResult[Int] = validateMonth("", "value", "err")
+      result mustBe a[Left[_, _]]
+      result.swap.getOrElse(Nil) must contain(FormError("value", "err"))
+    }
+  }
+}

--- a/test/forms/mappings/MappingsSpec.scala
+++ b/test/forms/mappings/MappingsSpec.scala
@@ -119,12 +119,38 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
       boundForm.value mustBe Some(MembersDob(day, month, year))
     }
 
+    "must bind a valid submission with short month format" in new DateOfBirthTest {
+      val day: Int = 30
+      val month: Int = 1
+      val year: Int = 1902
+
+      override val dayString: Option[String] = Some(day.toString)
+      override val monthString: Option[String] = Some("Jan")
+      override val yearString: Option[String] = Some(year.toString)
+
+      boundForm.errors must have length 0
+      boundForm.value mustBe Some(MembersDob(day, month, year))
+    }
+
+    "must bind a valid submission with long month format" in new DateOfBirthTest {
+      val day: Int = 30
+      val month: Int = 1
+      val year: Int = 1902
+
+      override val dayString: Option[String] = Some(day.toString)
+      override val monthString: Option[String] = Some("January")
+      override val yearString: Option[String] = Some(year.toString)
+
+      boundForm.errors must have length 0
+      boundForm.value mustBe Some(MembersDob(day, month, year))
+    }
+
     "must return errors when fields are missing" in new DateOfBirthTest {
       boundForm.errors must have length 3
       boundForm.errors.flatMap(_.messages) mustBe Seq(
-        "membersDob.error.invalidOrMissing.day",
-        "membersDob.error.invalidOrMissing.month",
-        "membersDob.error.invalidOrMissing.year"
+        "membersDob.error.missing.day",
+        "membersDob.error.missing.month",
+        "membersDob.error.missing.year"
       )
     }
 
@@ -135,9 +161,20 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
 
       boundForm.errors must have length 3
       boundForm.errors.flatMap(_.messages) mustBe Seq(
-        "membersDob.error.invalidOrMissing.day",
-        "membersDob.error.invalidOrMissing.month",
-        "membersDob.error.invalidOrMissing.year"
+        "membersDob.error.format.day",
+        "membersDob.error.format.month",
+        "membersDob.error.format.year"
+      )
+    }
+
+    "must enforce current year minimum" in new DateOfBirthTest {
+      override val dayString: Option[String] = Some("30")
+      override val monthString: Option[String] = Some("1")
+      override val yearString: Option[String] = Some("1899")
+
+      boundForm.errors must have length 1
+      boundForm.errors.flatMap(_.messages) mustBe Seq(
+        "membersDob.error.format.year"
       )
     }
 
@@ -148,7 +185,51 @@ class MappingsSpec extends AnyFreeSpec with Matchers with OptionValues with Mapp
 
       boundForm.errors must have length 1
       boundForm.errors.flatMap(_.messages) mustBe Seq(
-        "membersDob.error.invalidOrMissing.year"
+        "membersDob.error.format.year"
+      )
+    }
+
+    "must enforce day range maximum" in new DateOfBirthTest {
+      override val dayString: Option[String] = Some("32")
+      override val monthString: Option[String] = Some("1")
+      override val yearString: Option[String] = Some("2000")
+
+      boundForm.errors must have length 1
+      boundForm.errors.flatMap(_.messages) mustBe Seq(
+        "membersDob.error.format.day"
+      )
+    }
+
+    "must enforce day range minimum" in new DateOfBirthTest {
+      override val dayString: Option[String] = Some("0")
+      override val monthString: Option[String] = Some("1")
+      override val yearString: Option[String] = Some("2000")
+
+      boundForm.errors must have length 1
+      boundForm.errors.flatMap(_.messages) mustBe Seq(
+        "membersDob.error.format.day"
+      )
+    }
+
+    "must enforce month range maximum" in new DateOfBirthTest {
+      override val dayString: Option[String] = Some("30")
+      override val monthString: Option[String] = Some("13")
+      override val yearString: Option[String] = Some("2000")
+
+      boundForm.errors must have length 1
+      boundForm.errors.flatMap(_.messages) mustBe Seq(
+        "membersDob.error.format.month"
+      )
+    }
+
+    "must enforce month range minimum" in new DateOfBirthTest {
+      override val dayString: Option[String] = Some("20")
+      override val monthString: Option[String] = Some("0")
+      override val yearString: Option[String] = Some("2000")
+
+      boundForm.errors must have length 1
+      boundForm.errors.flatMap(_.messages) mustBe Seq(
+        "membersDob.error.format.month"
       )
     }
   }

--- a/test/models/response/ProtectionRecordSpec.scala
+++ b/test/models/response/ProtectionRecordSpec.scala
@@ -19,7 +19,6 @@ package models.response
 import base.SpecBase
 import models.response.RecordStatusMapped.Active
 import models.response.RecordTypeMapped.{FixedProtection2016, PcrPreCommencement}
-import org.scalatest.RecoverMethods.recoverToSucceededIf
 import play.api.libs.json._
 
 class ProtectionRecordSpec extends SpecBase {

--- a/test/utils/DateFieldFormatsSpec.scala
+++ b/test/utils/DateFieldFormatsSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import base.SpecBase

--- a/test/utils/DateFieldFormatsSpec.scala
+++ b/test/utils/DateFieldFormatsSpec.scala
@@ -1,0 +1,43 @@
+package utils
+
+import base.SpecBase
+
+class DateFieldFormatsSpec extends SpecBase{
+  "numericRegexp" - {
+    "should match any string containing only digits and periods" in {
+      DateFieldFormats.numericRegexp.r.matches("1.123.234.234.23") mustBe true
+    }
+
+    "should not match any string containing any non-digit or period characters" in {
+      DateFieldFormats.numericRegexp.r.matches("1.123.234.234.23a") mustBe false
+    }
+  }
+
+  "decimalRegexp" - {
+    "should match any string containing a valid decimal number" in {
+      DateFieldFormats.decimalRegexp.r.matches("1.12") mustBe true
+    }
+
+    "should not match any string containing any non-digit or period characters" in {
+      DateFieldFormats.decimalRegexp.r.matches("1.123a") mustBe false
+    }
+
+    "should not match any string containing an integer number" in {
+      DateFieldFormats.decimalRegexp.r.matches("11234") mustBe false
+    }
+  }
+
+  "integerRegexp" - {
+    "should match any string containing a valid integer number" in {
+      DateFieldFormats.integerRegexp.r.matches("12312312312") mustBe true
+    }
+
+    "should not match any string containing any non-digit characters" in {
+      DateFieldFormats.integerRegexp.r.matches("1324234a") mustBe false
+    }
+
+    "should not match any string containing a valid decimal number" in {
+      DateFieldFormats.integerRegexp.r.matches("123.3") mustBe false
+    }
+  }
+}

--- a/test/utils/DateFieldFormatsSpec.scala
+++ b/test/utils/DateFieldFormatsSpec.scala
@@ -11,6 +11,10 @@ class DateFieldFormatsSpec extends SpecBase{
     "should not match any string containing any non-digit or period characters" in {
       DateFieldFormats.numericRegexp.r.matches("1.123.234.234.23a") mustBe false
     }
+
+    "should not match an empty string" in {
+      DateFieldFormats.numericRegexp.r.matches("") mustBe false
+    }
   }
 
   "decimalRegexp" - {
@@ -25,6 +29,10 @@ class DateFieldFormatsSpec extends SpecBase{
     "should not match any string containing an integer number" in {
       DateFieldFormats.decimalRegexp.r.matches("11234") mustBe false
     }
+
+    "should not match an empty string" in {
+      DateFieldFormats.decimalRegexp.r.matches("") mustBe false
+    }
   }
 
   "integerRegexp" - {
@@ -38,6 +46,10 @@ class DateFieldFormatsSpec extends SpecBase{
 
     "should not match any string containing a valid decimal number" in {
       DateFieldFormats.integerRegexp.r.matches("123.3") mustBe false
+    }
+
+    "should not match an empty string" in {
+      DateFieldFormats.integerRegexp.r.matches("") mustBe false
     }
   }
 }

--- a/test/utils/DateTimeFormatsSpec.scala
+++ b/test/utils/DateTimeFormatsSpec.scala
@@ -21,10 +21,10 @@ import org.scalatest.matchers.must.Matchers
 import play.api.i18n.Lang
 import utils.DateTimeFormats.{dateTimeFormat, getCurrentDateTimestamp, longMonthFormat, shortMonthFormat}
 
+import java.time.Month._
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.temporal.ChronoField
-import java.time.{LocalDate, Month, ZoneId, ZonedDateTime}
-import java.time.Month._
+import java.time.{LocalDate, ZoneId, ZonedDateTime}
 import scala.util.control.Exception.nonFatalCatch
 
 class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {

--- a/test/utils/DateTimeFormatsSpec.scala
+++ b/test/utils/DateTimeFormatsSpec.scala
@@ -16,7 +16,6 @@
 
 package utils
 
-import com.github.tomakehurst.wiremock.common.DateTimeParser
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.i18n.Lang
@@ -24,7 +23,8 @@ import utils.DateTimeFormats.{dateTimeFormat, getCurrentDateTimestamp, longMonth
 
 import java.time.format.{DateTimeFormatter, DateTimeParseException}
 import java.time.temporal.ChronoField
-import java.time.{LocalDate, ZoneId, ZonedDateTime}
+import java.time.{LocalDate, Month, ZoneId, ZonedDateTime}
+import java.time.Month._
 import scala.util.control.Exception.nonFatalCatch
 
 class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
@@ -66,19 +66,21 @@ class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
     }
 
   ".shortMonthFormat" - {
+    val sept = LocalDate.of(2021, 9, 1).format(shortMonthFormat)
+
     val validValues: Seq[(String, Int)] = Seq(
-      "Jan" -> 1,
-      "Feb" -> 2,
-      "Mar" -> 3,
-      "Apr" -> 4,
-      "May" -> 5,
-      "Jun" -> 6,
-      "Jul" -> 7,
-      "Aug" -> 8,
-      "Sept" -> 9,
-      "Oct" -> 10,
-      "Nov" -> 11,
-      "Dec" -> 12
+      "Jan" -> JANUARY.getValue,
+      "Feb" -> FEBRUARY.getValue,
+      "Mar" -> MARCH.getValue,
+      "Apr" -> APRIL.getValue,
+      "May" -> MAY.getValue,
+      "Jun" -> JUNE.getValue,
+      "Jul" -> JULY.getValue,
+      "Aug" -> AUGUST.getValue,
+      sept  -> SEPTEMBER.getValue,
+      "Oct" -> OCTOBER.getValue,
+      "Nov" -> NOVEMBER.getValue,
+      "Dec" -> DECEMBER.getValue
     )
 
     validValues.foreach(scenario => testForMonthString(scenario._1, scenario._2, shortMonthFormat))
@@ -90,18 +92,18 @@ class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
 
   ".longMonthFormat" - {
     val validValues: Seq[(String, Int)] = Seq(
-      "January" -> 1,
-      "February" -> 2,
-      "March" -> 3,
-      "April" -> 4,
-      "May" -> 5,
-      "June" -> 6,
-      "July" -> 7,
-      "August" -> 8,
-      "September" -> 9,
-      "October" -> 10,
-      "November" -> 11,
-      "December" -> 12
+      "January"   -> JANUARY.getValue,
+      "February"  -> FEBRUARY.getValue,
+      "March"     -> MARCH.getValue,
+      "April"     -> APRIL.getValue,
+      "May"       -> MAY.getValue,
+      "June"      -> JUNE.getValue,
+      "July"      -> JULY.getValue,
+      "August"    -> AUGUST.getValue,
+      "September" -> SEPTEMBER.getValue,
+      "October"   -> OCTOBER.getValue,
+      "November"  -> NOVEMBER.getValue,
+      "December"  -> DECEMBER.getValue
     )
 
     validValues.foreach(scenario => testForMonthString(scenario._1, scenario._2, longMonthFormat))

--- a/test/utils/DateTimeFormatsSpec.scala
+++ b/test/utils/DateTimeFormatsSpec.scala
@@ -16,12 +16,16 @@
 
 package utils
 
+import com.github.tomakehurst.wiremock.common.DateTimeParser
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import play.api.i18n.Lang
-import utils.DateTimeFormats.{dateTimeFormat, getCurrentDateTimestamp}
+import utils.DateTimeFormats.{dateTimeFormat, getCurrentDateTimestamp, longMonthFormat, shortMonthFormat}
 
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+import java.time.temporal.ChronoField
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
+import scala.util.control.Exception.nonFatalCatch
 
 class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
 
@@ -51,6 +55,59 @@ class DateTimeFormatsSpec extends AnyFreeSpec with Matchers {
         ZonedDateTime.of(2025, 11, 11, 11, 11, 11, 11, ZoneId.of("Europe/London"))
       )
       result mustEqual "11 November 2025 at 11:11am"
+    }
+  }
+
+  def testForMonthString(monthStr: String, monthInt: Int, parser: DateTimeFormatter): Unit =
+    s"should convert the string: $monthStr to the int: $monthInt" in {
+      nonFatalCatch.opt(parser.parse(monthStr)).map(
+        _.get(ChronoField.MONTH_OF_YEAR)
+      ) mustBe Some(monthInt)
+    }
+
+  ".shortMonthFormat" - {
+    val validValues: Seq[(String, Int)] = Seq(
+      "Jan" -> 1,
+      "Feb" -> 2,
+      "Mar" -> 3,
+      "Apr" -> 4,
+      "May" -> 5,
+      "Jun" -> 6,
+      "Jul" -> 7,
+      "Aug" -> 8,
+      "Sept" -> 9,
+      "Oct" -> 10,
+      "Nov" -> 11,
+      "Dec" -> 12
+    )
+
+    validValues.foreach(scenario => testForMonthString(scenario._1, scenario._2, shortMonthFormat))
+
+    "should not parse any incorrect string" in {
+      assertThrows[DateTimeParseException](shortMonthFormat.parse("incorrect"))
+    }
+  }
+
+  ".longMonthFormat" - {
+    val validValues: Seq[(String, Int)] = Seq(
+      "January" -> 1,
+      "February" -> 2,
+      "March" -> 3,
+      "April" -> 4,
+      "May" -> 5,
+      "June" -> 6,
+      "July" -> 7,
+      "August" -> 8,
+      "September" -> 9,
+      "October" -> 10,
+      "November" -> 11,
+      "December" -> 12
+    )
+
+    validValues.foreach(scenario => testForMonthString(scenario._1, scenario._2, longMonthFormat))
+
+    "should not parse any incorrect string" in {
+      assertThrows[DateTimeParseException](longMonthFormat.parse("incorrect"))
     }
   }
 }

--- a/test/views/WhatYouWillNeedViewSpec.scala
+++ b/test/views/WhatYouWillNeedViewSpec.scala
@@ -43,22 +43,22 @@ class WhatYouWillNeedViewSpec extends SpecBase {
     }
 
     "display correct guidance and text" in new Setup {
-
       view.getElementsByTag("h1").text() mustBe messages(app)("whatYouWillNeed.heading")
 
       view.html.contains(messages(app)("whatYouWillNeed.p1"))
       view.text.contains(messages(app)("whatYouWillNeed.full-name"))
       view.text.contains(messages(app)("whatYouWillNeed.dob"))
       view.text.contains(messages(app)("whatYouWillNeed.nino"))
-      view.text.contains(messages(app)("whatYouWillNeed.pension-scheme-admin-check-ref"))
+      view.text.contains(messages(app)("whatYouWillNeed.pension-scheme-admin-check-ref.li"))
 
+      view.getElementsByTag("h2").first().text() mustBe messages(app)("whatYouWillNeed.pension_scheme_admin_check_ref.h2")
       view.text.contains(messages(app)("whatYouWillNeed.guidance.p1"))
       view.text.contains(messages(app)("whatYouWillNeed.guidance.p2"))
       view.text.contains(messages(app)("whatYouWillNeed.guidance.li.1"))
 
-      view.getElementsByClass("govuk-list govuk-list--bullet govuk-!-margin-bottom-6").last().getElementsByTag("a").text() mustBe
+      view.getElementsByClass("govuk-list govuk-list--bullet").last().getElementsByTag("a").text() mustBe
         messages(app)("whatYouWillNeed.guidance.li.2.linkText")
-      view.getElementsByClass("govuk-list govuk-list--bullet govuk-!-margin-bottom-6").last().getElementsByTag("a").attr("href") mustBe
+      view.getElementsByClass("govuk-list govuk-list--bullet").last().getElementsByTag("a").attr("href") mustBe
         "https://www.gov.uk/guidance/pension-schemes-protect-your-lifetime-allowance"
     }
   }

--- a/test/views/WhatYouWillNeedViewSpec.scala
+++ b/test/views/WhatYouWillNeedViewSpec.scala
@@ -19,7 +19,7 @@ package views
 import base.SpecBase
 import controllers.routes
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.jsoup.nodes.{Document, Element}
 import play.api.Application
 import play.api.i18n.Messages
 import play.api.mvc.AnyContentAsEmpty
@@ -36,9 +36,10 @@ class WhatYouWillNeedViewSpec extends SpecBase {
         "/members-protections-and-enhancements/account/sign-out-survey"
     }
 
-    "with correct breadcrumbs" in new Setup {
-      view.getElementsByClass("govuk-breadcrumbs__link").first().text() mustBe messages(app)("results.breadcrumbs.mps")
-      view.getElementsByClass("govuk-breadcrumbs__link").last().text() mustBe messages(app)("results.breadcrumbs.mpe")
+    "with correct back link" in new Setup {
+      val element: Element = view.getElementsByClass("govuk-back-link").first()
+      element.text mustBe messages(app)("Back")
+      element.attr("href") mustBe controllers.routes.MpsDashboardController.redirectToMps().url
     }
 
     "display correct guidance and text" in new Setup {

--- a/test/views/auth/SessionTimeoutViewSpec.scala
+++ b/test/views/auth/SessionTimeoutViewSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.auth
+
+import base.SpecBase
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import views.html.auth.SessionTimeoutView
+
+class SessionTimeoutViewSpec extends SpecBase {
+
+  "view" - {
+    "display correct guidance and text" in new Setup {
+      view.getElementsByTag("h1").text() mustBe messages(app)("For your security, we signed you out")
+
+      view.html.contains(messages(app)("sessionTimeout.signIn"))
+    }
+  }
+
+
+  trait Setup {
+    val app: Application = applicationBuilder(emptyUserAnswers).build()
+    implicit val msg: Messages = messages(app)
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
+
+    val view: Document = Jsoup.parse(app.injector.instanceOf[SessionTimeoutView].apply().body)
+  }
+
+}


### PR DESCRIPTION
- **LPE-783: Remove support for Welsh language from config.**
- **LPE-783: Change 'what you will need' button attributes to make it work like a button on spacebar presses**
- **LPE-783: Update timeout page**
- **LPE-783: Add spec for timeout page**
- **LPE-783: Print button should only show up when javascript is enabled**
- **LPE-783: Remove horizontal break lines**
- **LPE-783: Remove redundant CSS classes from certain form headers by refactoring relevant pages**
- **LPE-783: Reduced header size**
- **LPE-783: Replace start page breadcrumbs with MPS dashboard redirect back link**
- **LPE-783: Update start page content. Change link in second list to open in new tab. Amend some spacing for consistency with prototype.**
- **LPE-783: Update css to hide certain elements on print view.**
- **LPE-783: Make urls absolute.**
- **LPE-783: Add GOV.UK to all service page names**
- **LPE-774: Amend start page title**
- **LPE-783: Update date validation messages**
- **LPE-783: Add helper type**
- **LPE-783: Add date field formats.**
- **LPE-783: Add long and short month format parsers.**
- **LPE-783: Add missing parser scenario coverage**
- **LPE-783: Update mapping and formatting to include support for name month values.**
- **LPE-783: Add missing test scenarios.**
